### PR TITLE
Update requirements.txt to resolve vulnerability in Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,8 @@ matplotlib==3.7.1
 noise==1.2.2
 numpy==1.24.2
 pandas==1.5.3
-Pillow==9.5.0
+Pillow>=10.0.1
 rasterio==1.3.6
 Shapely==2.0.1
 streamlit==1.21.0
 streamlit_extras==0.2.7
-


### PR DESCRIPTION
Now requires Pillow >= 10.0.1 due to a vulnerability of previous versions.